### PR TITLE
Fix cursor and click event when on resize stop

### DIFF
--- a/src/ResizableHeader.tsx
+++ b/src/ResizableHeader.tsx
@@ -58,7 +58,8 @@ const AntdResizableHeader: React.FC<ComponentProp> = (props) => {
 
   const setBodyStyle = (active: boolean) => {
     document.body.style.userSelect = active ? 'none' : '';
-    document.body.style.cursor = active ? 'col-resize' : '';
+    document.body.style.pointerEvents = active ? 'none' : '';
+    document.documentElement.style.cursor = active ? 'col-resize' : '';
   };
 
   const onStart = (_: any, data: ResizeCallbackData) => {


### PR DESCRIPTION
When column has sorter and min or max width you can see pointer cursor on the another elements.
Also you can pointer cursor see this effect when drag so fast.
Also when you stop resize and "drop mouse" on some element with click event this event is run.

![chrome-capture](https://user-images.githubusercontent.com/15940894/130037366-1af91fa2-fa8c-4ad7-9f88-6d1d7e62e683.gif)
